### PR TITLE
Improve handling of optional variables

### DIFF
--- a/.github/terraform/main.tf
+++ b/.github/terraform/main.tf
@@ -14,6 +14,16 @@ variable "image" {
   type = string
 }
 
+variable "optional" {
+  type    = string
+  default = null
+
+  validation {
+    condition = var.optional == null || var.optional == "foo"
+    error_message = "`optional` must only be `null` or `\"foo\"`."
+  }
+}
+
 resource "docker_image" "web_server" {
   name         = var.image
   keep_locally = false

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,6 +45,7 @@ jobs:
           workspace: ${{ github.event.number }}
           variables: |-
             image: nginx:latest
+            optional:
       - name: Validate destroy
         run: |
           rc=0

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,6 +28,7 @@ jobs:
           workspace: ${{ github.event.number }}
           variables: |-
             image: nginx:latest
+            optional:
       - name: Validate apply
         run: |
           status="$(curl -fsSL -o /dev/null -w "%{http_code}" http://localhost:8000)"

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -48,12 +48,16 @@ runs:
         # Execute
         set -eo pipefail
 
+        # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
+        # pass those into Terraform:
+        # https://github.com/hashicorp/terraform/issues/29078
+        #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
         var_flags=()
         while read -r var; do
             var_flags+=(-var "${var:?}")
-        done < <(jq -r 'to_entries[] | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
 
         echo "::group::terraform init"
         terraform init

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -43,12 +43,16 @@ runs:
         # Destroy
         set -eo pipefail
 
+                # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
+        # pass those into Terraform:
+        # https://github.com/hashicorp/terraform/issues/29078
+        #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
         var_flags=()
         while read -r var; do
             var_flags+=(-var "${var:?}")
-        done < <(jq -r 'to_entries[] | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
 
         echo "::group::terraform init"
         terraform init

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -43,7 +43,7 @@ runs:
         # Destroy
         set -eo pipefail
 
-                # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
+        # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
         # pass those into Terraform:
         # https://github.com/hashicorp/terraform/issues/29078
         #


### PR DESCRIPTION
Terraform doesn't seem to have a way of letting CLI input variables [explicitly pass in `null`](https://github.com/hashicorp/terraform/issues/29078#issuecomment-872444502). To work around this we'll remove `null` variables and just defer to the default value.