### PR TITLE
Support allowing undeclared variables

### DIFF
--- a/.github/terraform/input-output/main.tf
+++ b/.github/terraform/input-output/main.tf
@@ -7,8 +7,8 @@ variable "optional" {
   default = null
 
   validation {
-    condition = var.optional == null || var.optional == "foo"
-    error_message = "`optional` must only be `null` or `\"foo\"`."
+    condition = var.optional == null || var.optional == "bar"
+    error_message = "`optional` must only be `null` or `\"bar\"`."
   }
 }
 

--- a/.github/terraform/input-output/main.tf
+++ b/.github/terraform/input-output/main.tf
@@ -1,0 +1,21 @@
+variable "required" {
+  type = object
+}
+
+variable "optional" {
+  type    = string
+  default = null
+
+  validation {
+    condition = var.optional == null || var.optional == "foo"
+    error_message = "`optional` must only be `null` or `\"foo\"`."
+  }
+}
+
+output "required" {
+  value = var.required
+}
+
+output "optional" {
+  value = var.optional
+}

--- a/.github/terraform/input-output/main.tf
+++ b/.github/terraform/input-output/main.tf
@@ -1,5 +1,5 @@
 variable "required" {
-  type = object
+  type = string
 }
 
 variable "optional" {

--- a/.github/terraform/web-server/main.tf
+++ b/.github/terraform/web-server/main.tf
@@ -14,16 +14,6 @@ variable "image" {
   type = string
 }
 
-variable "optional" {
-  type    = string
-  default = null
-
-  validation {
-    condition = var.optional == null || var.optional == "foo"
-    error_message = "`optional` must only be `null` or `\"foo\"`."
-  }
-}
-
 resource "docker_image" "web_server" {
   name         = var.image
   keep_locally = false

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -78,7 +78,23 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - id: deploy-null
+      - name: Deploy null (implicit)
+        id: deploy-null-implicit
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: required
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+        env:
+          outcome: ${{ steps.deploy-null.outcome }}
+          json_kv: ${{ steps.deploy-null.outputs.json-kv }}
+      - name: Deploy null (explicit)
+        id: deploy-null-explicit
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -91,8 +107,41 @@ jobs:
           [[ "$outcome" == "success" ]] || exit 1
           jq -er '.optional == null' <<<"${json_kv}" || exit 1
         env:
-          outcome: ${{ steps.deploy-null.outcome }}
-          json_kv: ${{ steps.deploy-null.outputs.json-kv }}
+          outcome: ${{ steps.deploy-null-explicit.outcome }}
+          json_kv: ${{ steps.deploy-null-explicit.outputs.json-kv }}
+      - name: Deploy null (blank)
+        id: deploy-null-blank
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: required
+            optional:
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+        env:
+          outcome: ${{ steps.deploy-null-blank.outcome }}
+          json_kv: ${{ steps.deploy-null-blank.outputs.json-kv }}
+      - name: Deploy null (empty string)
+        id: deploy-null-empty-string
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: required
+            optional: ""
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+        env:
+          outcome: ${{ steps.deploy-null-empty-string.outcome }}
+          json_kv: ${{ steps.deploy-null-empty-string.outputs.json-kv }}
+
 
   test-undeclared-variable:
     name: Test Undeclared Variable
@@ -150,5 +199,7 @@ jobs:
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
+          jq -e '.optional == "foo"' <<<"${json_kv}" || exit 1
         env:
           outcome: ${{ steps.deploy-undeclared-declared.outcome }}
+          json_kv: ${{ steps.deploy-undeclared-declared.outputs.json-kv }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -171,7 +171,7 @@ jobs:
           outcome: ${{ steps.destroy-null-blank.outcome }}
 
       - name: Apply Null (invalid)
-        id: deploy-invalid
+        id: apply-null-invalid
         uses: ./apply
         with:
           dir: .github/terraform/input-output

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -106,3 +106,18 @@ jobs:
           [[ "$outcome" == "success" ]] || exit 1
         env:
           outcome: ${{ steps.deploy-allow-undeclared.outcome }}
+      - id: deploy-allow-undeclared-declared
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: required
+            optional: foo
+          undeclared: |
+            - optional
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.deploy-allow-undeclared-declared.outcome }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -250,9 +250,8 @@ jobs:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
+          optional-variables: |-
             dne: bar
-          allow-undeclared: |
-            - dne
         continue-on-error: true
       - name: Validate Apply
         run: |
@@ -268,9 +267,8 @@ jobs:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
+          optional-variables: |-
             dne: bar
-          allow-undeclared: |
-            - dne
         continue-on-error: true
       - name: Validate Destroy
         run: |
@@ -285,9 +283,8 @@ jobs:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
+          optional-variables: |-
             optional: bar  # Pretend like `dne` was defined within the Terraform project
-          allow-undeclared: |
-            - optional
         continue-on-error: true
       - name: Validate
         run: |
@@ -303,9 +300,8 @@ jobs:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
+          optional-variables: |-
             optional: bar  # Pretend like `dne` was defined within the Terraform project
-          allow-undeclared: |
-            - optional
         continue-on-error: true
       - name: Validate Destroy
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -84,12 +84,12 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
+            required: foo
         continue-on-error: true
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
-          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+          jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
           outcome: ${{ steps.deploy-null-implicit.outcome }}
           json_kv: ${{ steps.deploy-null-implicit.outputs.json-kv }}
@@ -99,13 +99,13 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
+            required: foo
             optional: null
         continue-on-error: true
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
-          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+          jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
           outcome: ${{ steps.deploy-null-explicit.outcome }}
           json_kv: ${{ steps.deploy-null-explicit.outputs.json-kv }}
@@ -115,32 +115,32 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
+            required: foo
             optional:
         continue-on-error: true
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
-          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+          jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
           outcome: ${{ steps.deploy-null-blank.outcome }}
           json_kv: ${{ steps.deploy-null-blank.outputs.json-kv }}
-      - name: Deploy null (empty string)
-        id: deploy-null-empty-string
+      - name: Deploy null (invalid)
+        id: deploy-null-invalid
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
-            optional: ""
+            required: foo
+            optional: ""  # Empty string isn't null
         continue-on-error: true
       - name: Validate
         run: |
-          [[ "$outcome" == "success" ]] || exit 1
-          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+          [[ "$outcome" == "failure" ]] || exit 1
+          jq -e '.optional != null' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-null-empty-string.outcome }}
-          json_kv: ${{ steps.deploy-null-empty-string.outputs.json-kv }}
+          outcome: ${{ steps.deploy-null-invalid.outcome }}
+          json_kv: ${{ steps.deploy-null-invalid.outputs.json-kv }}
 
 
   test-undeclared-variable:
@@ -161,8 +161,8 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
-            dne: value undeclared for variable
+            required: foo
+            dne: bar
         continue-on-error: true
       - name: Validate
         run: |
@@ -175,31 +175,33 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
-            dne: value undeclared for variable
+            required: foo
+            dne: bar
           undeclared: |
             - dne
         continue-on-error: true
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
+          jq -e '.dne == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
           outcome: ${{ steps.deploy-undeclared-allowed.outcome }}
+          json_kv: ${{ steps.deploy-undeclared-allowed.outputs.json-kv }}
       - name: Deploy undeclared (declared)
         id: deploy-undeclared-declared
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: required
-            optional: foo
+            required: foo
+            optional: bar
           undeclared: |
             - optional
         continue-on-error: true
       - name: Validate
         run: |
           [[ "$outcome" == "success" ]] || exit 1
-          jq -e '.optional == "foo"' <<<"${json_kv}" || exit 1
+          jq -e '.optional == "bar"' <<<"${json_kv}" >/dev/null || exit 1
         env:
           outcome: ${{ steps.deploy-undeclared-declared.outcome }}
           json_kv: ${{ steps.deploy-undeclared-declared.outputs.json-kv }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,3 +67,50 @@ jobs:
               docker ps
               exit 1
           fi
+
+  test-undeclared-variable:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
+          # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
+          terraform_version: "~1.9"
+      - name: Deploy Terraform resources
+        id: terraform
+        uses: ./apply
+        with:
+          dir: .github/terraform
+          workspace: ${{ env.workspace }}
+          variables: |-
+            image: nginx:latest
+            dne: value undeclared for variable
+      # - name: Validate apply
+      #   run: |
+      #     status="$(curl -fsSL -o /dev/null -w "%{http_code}" http://localhost:8000)"
+      #     if [[ "$status" -ne 200 ]]; then
+      #         echo "status=$status"
+      #         docker ps
+      #         exit 1
+      #     fi
+      # - name: Destroy Terraform resources
+      #   uses: ./destroy
+      #   with:
+      #     dir: .github/terraform
+      #     workspace: ${{ env.workspace }}
+      #     variables: |-
+      #       image: nginx:latest
+      #       optional:
+      # - name: Validate destroy
+      #   run: |
+      #     rc=0
+      #     curl -fsSL http://localhost:8000 || rc=$?
+      #     if [[ "$rc" -ne 7 ]]; then
+      #         echo "rc=$rc"
+      #         docker ps
+      #         exit 1
+      #     fi

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,8 +21,8 @@ env:
                 'unknown') }}
 
 jobs:
-  test:
-    name: Test
+  test-web-server:
+    name: Test Web Server
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,11 +37,10 @@ jobs:
         id: terraform
         uses: ./apply
         with:
-          dir: .github/terraform
+          dir: .github/terraform/web-server
           workspace: ${{ env.workspace }}
           variables: |-
             image: nginx:latest
-            optional:
       - name: Validate apply
         run: |
           status="$(curl -fsSL -o /dev/null -w "%{http_code}" http://localhost:8000)"
@@ -53,11 +52,10 @@ jobs:
       - name: Destroy Terraform resources
         uses: ./destroy
         with:
-          dir: .github/terraform
+          dir: .github/terraform/web-server
           workspace: ${{ env.workspace }}
           variables: |-
             image: nginx:latest
-            optional:
       - name: Validate destroy
         run: |
           rc=0
@@ -69,7 +67,7 @@ jobs:
           fi
 
   test-undeclared-variable:
-    name: Test
+    name: Test Undeclared Variable
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -84,35 +82,13 @@ jobs:
         id: terraform
         uses: ./apply
         with:
-          dir: .github/terraform
-          workspace: ${{ env.workspace }}
+          dir: .github/terraform/input-output
           variables: |-
-            image: nginx:latest
+            required: {"key", "value"}
             dne: value undeclared for variable
           undeclared: |
             - dne
-      # - name: Validate apply
-      #   run: |
-      #     status="$(curl -fsSL -o /dev/null -w "%{http_code}" http://localhost:8000)"
-      #     if [[ "$status" -ne 200 ]]; then
-      #         echo "status=$status"
-      #         docker ps
-      #         exit 1
-      #     fi
-      # - name: Destroy Terraform resources
-      #   uses: ./destroy
-      #   with:
-      #     dir: .github/terraform
-      #     workspace: ${{ env.workspace }}
-      #     variables: |-
-      #       image: nginx:latest
-      #       optional:
-      # - name: Validate destroy
-      #   run: |
-      #     rc=0
-      #     curl -fsSL http://localhost:8000 || rc=$?
-      #     if [[ "$rc" -ne 7 ]]; then
-      #         echo "rc=$rc"
-      #         docker ps
-      #         exit 1
-      #     fi
+      - name: Destroy Terraform resources
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -91,8 +91,8 @@ jobs:
           [[ "$outcome" == "success" ]] || exit 1
           jq -er '.optional == null' <<<"${json_kv}" || exit 1
         env:
-          outcome: ${{ steps.deploy-null.outcome }}
-          json_kv: ${{ steps.deploy-null.outputs.json-kv }}
+          outcome: ${{ steps.deploy-null-implicit.outcome }}
+          json_kv: ${{ steps.deploy-null-implicit.outputs.json-kv }}
       - name: Deploy null (explicit)
         id: deploy-null-explicit
         uses: ./apply

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -78,23 +78,38 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - name: Deploy null (implicit)
-        id: deploy-null-implicit
+
+      - name: Apply Null (implicit)
+        id: apply-null-implicit
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "success" ]] || exit 1
           jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-null-implicit.outcome }}
-          json_kv: ${{ steps.deploy-null-implicit.outputs.json-kv }}
-      - name: Deploy null (explicit)
-        id: deploy-null-explicit
+          outcome: ${{ steps.apply-null-implicit.outcome }}
+          json_kv: ${{ steps.apply-null-implicit.outputs.json-kv }}
+      - name: Destroy Null (implicit)
+        id: destroy-null-implicit
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-null-implicit.outcome }}
+
+      - name: Apply Null (explicit)
+        id: apply-null-explicit
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -102,15 +117,30 @@ jobs:
             required: foo
             optional: null
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "success" ]] || exit 1
           jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-null-explicit.outcome }}
-          json_kv: ${{ steps.deploy-null-explicit.outputs.json-kv }}
-      - name: Deploy null (blank)
-        id: deploy-null-blank
+          outcome: ${{ steps.apply-null-explicit.outcome }}
+          json_kv: ${{ steps.apply-null-explicit.outputs.json-kv }}
+      - name: Destroy Null (explicit)
+        id: destroy-null-explicit
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            optional: null
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-null-explicit.outcome }}
+
+      - name: Apply Null (blank)
+        id: apply-null-blank
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -118,15 +148,30 @@ jobs:
             required: foo
             optional:
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "success" ]] || exit 1
           jq -e '.optional == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-null-blank.outcome }}
-          json_kv: ${{ steps.deploy-null-blank.outputs.json-kv }}
-      - name: Deploy null (invalid)
-        id: deploy-null-invalid
+          outcome: ${{ steps.apply-null-blank.outcome }}
+          json_kv: ${{ steps.apply-null-blank.outputs.json-kv }}
+      - name: Destroy Null (blank)
+        id: destroy-null-blank
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            optional:
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-null-blank.outcome }}
+
+      - name: Apply Null (invalid)
+        id: deploy-invalid
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -134,14 +179,27 @@ jobs:
             required: foo
             optional: ""  # Empty string isn't null
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "failure" ]] || exit 1
           [[ "$json_kv" == "" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-null-invalid.outcome }}
-          json_kv: ${{ steps.deploy-null-invalid.outputs.json-kv }}
-
+          outcome: ${{ steps.apply-null-invalid.outcome }}
+          json_kv: ${{ steps.apply-null-invalid.outputs.json-kv }}
+      - name: Destroy Null (invalid)
+        id: destroy-null-invalid
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            optional: ""  # Empty string isn't null
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-null-blank.outcome }}
 
   test-undeclared-variable:
     name: Test Undeclared Variable
@@ -155,8 +213,9 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - name: Deploy undeclared (failure)
-        id: deploy-undeclared-failure
+
+      - name: Apply Undeclared (failure)
+        id: apply-undeclared-failure
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -164,13 +223,28 @@ jobs:
             required: foo
             dne: bar
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "failure" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-undeclared-failure.outcome }}
-      - name: Deploy undeclared (allowed)
-        id: deploy-undeclared-allowed
+          outcome: ${{ steps.apply-undeclared-failure.outcome }}
+      - name: Destroy Undeclared (failure)
+        id: destroy-undeclared-failure
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            dne: bar
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "failure" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-undeclared-failure.outcome }}
+
+      - name: Apply Undeclared (allowed)
+        id: apply-undeclared-allowed
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -180,21 +254,38 @@ jobs:
           undeclared: |
             - dne
         continue-on-error: true
-      - name: Validate
+      - name: Validate Apply
         run: |
           [[ "$outcome" == "success" ]] || exit 1
           jq -e '.dne == null' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-undeclared-allowed.outcome }}
-          json_kv: ${{ steps.deploy-undeclared-allowed.outputs.json-kv }}
-      - name: Deploy undeclared (declared)
-        id: deploy-undeclared-declared
+          outcome: ${{ steps.apply-undeclared-allowed.outcome }}
+          json_kv: ${{ steps.apply-undeclared-allowed.outputs.json-kv }}
+      - name: Destroy Undeclared (allowed)
+        id: destroy-undeclared-allowed
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            dne: bar
+          undeclared: |
+            - dne
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-undeclared-allowed.outcome }}
+
+      - name: Apply Undeclared (declared)
+        id: apply-undeclared-declared
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
             required: foo
-            optional: bar
+            optional: bar  # Pretend like `dne` was defined within the Terraform project
           undeclared: |
             - optional
         continue-on-error: true
@@ -203,5 +294,21 @@ jobs:
           [[ "$outcome" == "success" ]] || exit 1
           jq -e '.optional == "bar"' <<<"${json_kv}" >/dev/null || exit 1
         env:
-          outcome: ${{ steps.deploy-undeclared-declared.outcome }}
-          json_kv: ${{ steps.deploy-undeclared-declared.outputs.json-kv }}
+          outcome: ${{ steps.apply-undeclared-declared.outcome }}
+          json_kv: ${{ steps.apply-undeclared-declared.outputs.json-kv }}
+      - name: Destroy Undeclared (declared)
+        id: destroy-undeclared-declared
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+            optional: bar  # Pretend like `dne` was defined within the Terraform project
+          undeclared: |
+            - optional
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy-undeclared-declared.outcome }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,6 +66,34 @@ jobs:
               exit 1
           fi
 
+  test-null-variable:
+    name: Test Null Variable
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
+          # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
+          terraform_version: "~1.9"
+      - id: deploy-null
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: required
+            optional: null
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+          jq -er '.optional == null' <<<"${json_kv}" || exit 1
+        env:
+          outcome: ${{ steps.deploy-null.outcome }}
+          json_kv: ${{ steps.deploy-null.outputs.json-kv }}
+
   test-undeclared-variable:
     name: Test Undeclared Variable
     runs-on: ubuntu-latest
@@ -78,7 +106,8 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - id: deploy-undeclared
+      - name: Deploy undeclared (failure)
+        id: deploy-undeclared-failure
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -90,8 +119,9 @@ jobs:
         run: |
           [[ "$outcome" == "failure" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-undeclared.outcome }}
-      - id: deploy-allow-undeclared
+          outcome: ${{ steps.deploy-undeclared-failure.outcome }}
+      - name: Deploy undeclared (allowed)
+        id: deploy-undeclared-allowed
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -105,8 +135,9 @@ jobs:
         run: |
           [[ "$outcome" == "success" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-allow-undeclared.outcome }}
-      - id: deploy-allow-undeclared-declared
+          outcome: ${{ steps.deploy-undeclared-allowed.outcome }}
+      - name: Deploy undeclared (declared)
+        id: deploy-undeclared-declared
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -120,4 +151,4 @@ jobs:
         run: |
           [[ "$outcome" == "success" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-allow-undeclared-declared.outcome }}
+          outcome: ${{ steps.deploy-undeclared-declared.outcome }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -78,7 +78,15 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - name: Deploy Terraform resources
+      - name: Deploy undeclared
+        id: terraform
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: "required"
+            dne: value undeclared for variable
+      - name: Deploy allow undeclared
         id: terraform
         uses: ./apply
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -89,6 +89,8 @@ jobs:
           variables: |-
             image: nginx:latest
             dne: value undeclared for variable
+          undeclared: |
+            - dne
       # - name: Validate apply
       #   run: |
       #     status="$(curl -fsSL -o /dev/null -w "%{http_code}" http://localhost:8000)"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -105,4 +105,4 @@ jobs:
         run: |
           [[ "$outcome" == "success" ]] || exit 1
         env:
-          outcome: ${{ steps.deploy-allow=undeclared.outcome }}
+          outcome: ${{ steps.deploy-allow-undeclared.outcome }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -84,11 +84,7 @@ jobs:
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: {"key", "value"}
+            required: "required"
             dne: value undeclared for variable
           undeclared: |
             - dne
-      - name: Destroy Terraform resources
-        uses: ./destroy
-        with:
-          dir: .github/terraform/input-output

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -79,7 +79,6 @@ jobs:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
       - name: Deploy undeclared
-        id: terraform
         uses: ./apply
         with:
           dir: .github/terraform/input-output
@@ -87,7 +86,6 @@ jobs:
             required: "required"
             dne: value undeclared for variable
       - name: Deploy allow undeclared
-        id: terraform
         uses: ./apply
         with:
           dir: .github/terraform/input-output

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -251,7 +251,7 @@ jobs:
           variables: |-
             required: foo
             dne: bar
-          undeclared: |
+          allow-undeclared: |
             - dne
         continue-on-error: true
       - name: Validate Apply
@@ -269,7 +269,7 @@ jobs:
           variables: |-
             required: foo
             dne: bar
-          undeclared: |
+          allow-undeclared: |
             - dne
         continue-on-error: true
       - name: Validate Destroy
@@ -286,7 +286,7 @@ jobs:
           variables: |-
             required: foo
             optional: bar  # Pretend like `dne` was defined within the Terraform project
-          undeclared: |
+          allow-undeclared: |
             - optional
         continue-on-error: true
       - name: Validate
@@ -304,7 +304,7 @@ jobs:
           variables: |-
             required: foo
             optional: bar  # Pretend like `dne` was defined within the Terraform project
-          undeclared: |
+          allow-undeclared: |
             - optional
         continue-on-error: true
       - name: Validate Destroy

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Validate
         run: |
           [[ "$outcome" == "failure" ]] || exit 1
-          jq -e '.optional != null' <<<"${json_kv}" >/dev/null || exit 1
+          [[ "$json_kv" == "" ]] || exit 1
         env:
           outcome: ${{ steps.deploy-null-invalid.outcome }}
           json_kv: ${{ steps.deploy-null-invalid.outputs.json-kv }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -78,19 +78,31 @@ jobs:
           # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
           # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
           terraform_version: "~1.9"
-      - name: Deploy undeclared
+      - id: deploy-undeclared
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: "required"
+            required: required
             dne: value undeclared for variable
-      - name: Deploy allow undeclared
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "failure" ]] || exit 1
+        env:
+          outcome: ${{ steps.deploy-undeclared.outcome }}
+      - id: deploy-allow-undeclared
         uses: ./apply
         with:
           dir: .github/terraform/input-output
           variables: |-
-            required: "required"
+            required: required
             dne: value undeclared for variable
           undeclared: |
             - dne
+        continue-on-error: true
+      - name: Validate
+        run: |
+          [[ "$outcome" == "success" ]] || exit 1
+        env:
+          outcome: ${{ steps.deploy-allow=undeclared.outcome }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -308,3 +308,47 @@ jobs:
           [[ "$outcome" == "success" ]] || exit 1
         env:
           outcome: ${{ steps.destroy-undeclared-declared.outcome }}
+
+  test-duplicate-variable:
+    name: Test Duplicate Variable
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Avoiding using Terraform 1.10 at this time as it does not work well with `apply --auto-approve`:
+          # https://github.com/hashicorp/terraform/issues/36106#issuecomment-2506181760
+          terraform_version: "~1.9"
+
+      - name: Apply
+        id: apply
+        uses: ./apply
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+          optional-variables: |-
+            required: bar
+        continue-on-error: true
+      - name: Validate Apply
+        run: |
+          [[ "$outcome" == "failure" ]] || exit 1
+        env:
+          outcome: ${{ steps.apply.outcome }}
+      - name: Destroy
+        id: destroy
+        uses: ./destroy
+        with:
+          dir: .github/terraform/input-output
+          variables: |-
+            required: foo
+          optional-variables: |-
+            required: bar
+        continue-on-error: true
+      - name: Validate Destroy
+        run: |
+          [[ "$outcome" == "failure" ]] || exit 1
+        env:
+          outcome: ${{ steps.destroy.outcome }}

--- a/apply/README.md
+++ b/apply/README.md
@@ -6,14 +6,14 @@ Perform a Terraform plan and [apply](https://developer.hashicorp.com/terraform/c
 
 The `terraform-action/apply` action supports the following inputs:
 
-| Name               | Description | Required | Example |
-|:-------------------|:------------|:---------|:--------|
-| `dir`              | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
-| `workspace`        | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
-| `lock`             | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
-| `variables`        | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `allow-undeclared` | YAML or JSON list containing the names of variable keys which may safely be ignored when they are specified as input but are undeclared within the called Terraform project. | No |<pre><code class="language-yaml">- availability_zone_names</code></pre> |
-| `token`            | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
+| Name                 | Description | Required | Example |
+|:---------------------|:------------|:---------|:--------|
+| `dir`                | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
+| `workspace`          | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
+| `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
+| `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `optional-variables` | YAML or JSON object containing key/value pairs of input values which may can be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs
 

--- a/apply/README.md
+++ b/apply/README.md
@@ -11,7 +11,7 @@ The `terraform-action/apply` action supports the following inputs:
 | `dir`                | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
 | `workspace`          | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
 | `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
-| `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). Any variables specified here must be declared by the Terraform project or otherwise an error will be thrown. | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
 | `optional-variables` | YAML or JSON object containing key/value pairs of input values which may can be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
 | `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 

--- a/apply/README.md
+++ b/apply/README.md
@@ -12,7 +12,7 @@ The `terraform-action/apply` action supports the following inputs:
 | `workspace`          | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
 | `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
 | `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). Any variables specified here must be declared by the Terraform project or otherwise an error will be thrown. | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `optional-variables` | YAML or JSON object containing key/value pairs of input values which may can be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `optional-variables` | YAML or JSON object containing key/value pairs of input values which will be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
 | `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs

--- a/apply/README.md
+++ b/apply/README.md
@@ -6,13 +6,14 @@ Perform a Terraform plan and [apply](https://developer.hashicorp.com/terraform/c
 
 The `terraform-action/apply` action supports the following inputs:
 
-| Name             | Description | Required | Example |
-|:-----------------|:------------|:---------|:--------|
-| `dir`            | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
-| `workspace`      | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
-| `lock`           | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
-| `variables`      | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `token`          | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
+| Name               | Description | Required | Example |
+|:-------------------|:------------|:---------|:--------|
+| `dir`              | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
+| `workspace`        | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
+| `lock`             | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
+| `variables`        | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `allow-undeclared` | YAML or JSON list containing the names of variable keys which may safely be ignored when they are specified as input but are undeclared within the called Terraform project. | No |<pre><code class="language-yaml">- availability_zone_names</code></pre> |
+| `token`            | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs
 

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -17,7 +17,7 @@ inputs:
   variables:
     description: YAML or JSON object containing key/value pairs specifying input values.
     required: false
-  undeclared:
+  allow-undeclared:
     description: >-
       YAML or JSON list containing the names of variable keys which may safely be ignored
       when the are specified as input but are undeclared by the called Terrafrom project.
@@ -42,7 +42,7 @@ runs:
         # Terraform variables
         set -eo pipefail
         variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
-        undeclared_json="$(yq '. // []' -o json <<<"${undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
+        allow_undeclared_json="$(yq '. // []' -o json <<<"${allow_undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -51,13 +51,13 @@ runs:
             jq <<<"${variables_json}"
             echo "EOF"
 
-            echo "undeclared-json<<EOF"
-            jq <<<"${undeclared_json}"
+            echo "allow-undeclared-json<<EOF"
+            jq <<<"${allow_undeclared_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:
         variables: ${{ inputs.variables }}
-        undeclared: ${{ inputs.undeclared }}
+        allow_undeclared: ${{ inputs.allow-undeclared }}
     - name: Terraform apply
       shell: bash
       run: |
@@ -70,16 +70,16 @@ runs:
         #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
-        var_flags=()
-        env_vars=()
+        tf_var_flags=()
+        tf_var_envs=()
         while read -r json; do
             key="$(jq -re '.key' <<<"${json}")"
             value="$(jq -re '.value | tostring' <<<"${json}")"
 
-            if jq -e --arg key "$key" 'any(index($key))' <<<"${undeclared_json}"; then
-                env_vars+=(TF_VAR_${key}="${value}")
+            if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
+                tf_var_envs+=(TF_VAR_${key}="${value}")
             else
-                var_flags+=(-var "${key}=${value}")
+                tf_var_flags+=(-var "${key}=${value}")
             fi
         done < <(jq -cr 'to_entries[] | select(.value != null)' <<<"${variables_json}")
 
@@ -94,7 +94,7 @@ runs:
         fi
 
         echo "::group::terraform apply"
-        (set -x; env "${env_vars[@]}" terraform apply -auto-approve -lock="$lock" -input=false "${var_flags[@]}")
+        (set -x; env "${tf_var_envs[@]}" terraform apply -auto-approve -lock="$lock" -input=false "${tf_var_flags[@]}")
         echo "::endgroup::"
       env:
         # Allow HTTPS token access to remote modules. Using environmental variables to
@@ -106,7 +106,7 @@ runs:
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
         variables_json: ${{ steps.variables.outputs.variables-json }}
-        undeclared_json: ${{ steps.variables.outputs.undeclared-json }}
+        allow_undeclared_json: ${{ steps.variables.outputs.allow-undeclared-json }}
       working-directory: ${{ inputs.dir }}
     - name: Terraform outputs
       id: outputs

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -22,9 +22,9 @@ inputs:
     required: false
   optional-variables:
     description: >-
-      YAML or JSON object containing key/value pairs of input values which may can be
-      ignored if the Terraform project doesn't declare them. Typically, users should prefer
-      using `variables` instead.
+      YAML or JSON object containing key/value pairs of input values which will be ignored
+      if the Terraform project doesn't declare them. Typically, users should prefer using
+      `variables` instead.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -17,6 +17,11 @@ inputs:
   variables:
     description: YAML or JSON object containing key/value pairs specifying input values.
     required: false
+  undeclared:
+    description: >-
+      YAML or JSON list containing the names of variable keys which may safely be ignored
+      when the are specified as input but are undeclared by the called Terrafrom project.
+    required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
     default: ${{ github.token }}
@@ -37,12 +42,17 @@ runs:
         # Terraform variables
         set -eo pipefail
         variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("root element must be an object") end')"
+        undeclared_json="$(yq '. // []' -o json <<<"${variables}" | jq -r 'if type == "array" then . else error("root element must be a list") end')"
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
-            echo "json<<EOF"
+            echo "variables-json<<EOF"
             jq <<<"${variables_json}"
+            echo "EOF"
+
+            echo "undeclared-json<<EOF"
+            jq <<<"${undeclared_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:
@@ -53,16 +63,24 @@ runs:
         # Execute
         set -eo pipefail
 
-        # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
-        # pass those into Terraform:
+        # Convert JSON variables into CLI flags or environmental variables. We'll remove
+        # entries with `null` values as we cannot pass those into Terraform:
         # https://github.com/hashicorp/terraform/issues/29078
         #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
         var_flags=()
-        while read -r var; do
-            var_flags+=(-var "${var:?}")
-        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
+        env_vars=()
+        while read -r json; do
+            key="$(jq -re '.key' <<<"${json}")"
+            value="$(jq -re '.value | tostring' <<<"${json}")"
+
+            if jq -e --arg key "$key" 'any(index($key))' <<<"${undeclared_json}"; then
+                env_vars+=(TF_VAR_${key}="${value}")
+            else
+                var_flags+=(-var "${key}=${value}")
+            fi
+        done < <(jq -cr 'to_entries[] | select(.value != null)' <<<"${variables_json}")
 
         echo "::group::terraform init"
         terraform init
@@ -75,7 +93,7 @@ runs:
         fi
 
         echo "::group::terraform apply"
-        (set -x; terraform apply -auto-approve -lock="$lock" -input=false "${var_flags[@]}")
+        (set -x; env "${env_vars[@]}" terraform apply -auto-approve -lock="$lock" -input=false "${var_flags[@]}")
         echo "::endgroup::"
       env:
         # Allow HTTPS token access to remote modules. Using environmental variables to
@@ -86,7 +104,8 @@ runs:
 
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
-        variables_json: ${{ steps.variables.outputs.json }}
+        variables_json: ${{ steps.variables.outputs.variables-json }}
+        undeclared_json: ${{ steps.variables.outputs.undeclared-json }}
       working-directory: ${{ inputs.dir }}
     - name: Terraform outputs
       id: outputs

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -48,10 +48,10 @@ runs:
         required_vars_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
         optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
 
-        # Keys may only be defined once in either of the input variable maps
+        # Variables may only be defined once in either of the input variable maps
         duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
         if [[ -n "$duplicate_str" ]]; then
-            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_str" >&2
+            echo "Input variables must not be defined in both \`variables\` and \`optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1
         fi
 

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -49,7 +49,7 @@ runs:
         optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
 
         # Variables may only be defined once in either of the input variable maps
-        duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        duplicate_str="$(jq -nr --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
         if [[ -n "$duplicate_str" ]]; then
             echo "Input variables must not be defined in both \`variables\` and \`optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -41,8 +41,8 @@ runs:
       run: |
         # Terraform variables
         set -eo pipefail
-        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("root element must be an object") end')"
-        undeclared_json="$(yq '. // []' -o json <<<"${variables}" | jq -r 'if type == "array" then . else error("root element must be a list") end')"
+        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
+        undeclared_json="$(yq '. // []' -o json <<<"${undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -57,6 +57,7 @@ runs:
         } | tee -a "$GITHUB_OUTPUT"
       env:
         variables: ${{ inputs.variables }}
+        undeclared: ${{ inputs.undeclared }}
     - name: Terraform apply
       shell: bash
       run: |

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -20,7 +20,7 @@ inputs:
   allow-undeclared:
     description: >-
       YAML or JSON list containing the names of variable keys which may safely be ignored
-      when the are specified as input but are undeclared by the called Terrafrom project.
+      when they are specified as input but are undeclared within the called Terraform project.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -76,6 +76,10 @@ runs:
             key="$(jq -re '.key' <<<"${json}")"
             value="$(jq -re '.value | tostring' <<<"${json}")"
 
+            # Prefer using flags where possible as these will error when they define a variable
+            # which the Terraform project does not accept (possibly a typo). In some scenarios,
+            # such as deprecations, it's nice to use environmental variables which when unused
+            # do not produce these errors.
             if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
                 tf_var_envs+=(TF_VAR_${key}="${value}")
             else

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -48,10 +48,10 @@ runs:
         required_vars_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
         optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
 
-        # Keys may only be defined once in either of the input lists
-        duplicate_vars_str="$(jq -n --argjson req "$required_json" --argjson opt "$optional_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
-        if [[ -n "$duplicate_vars_str" ]]; then
-            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_vars_str" >&2
+        # Keys may only be defined once in either of the input variable maps
+        duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        if [[ -n "$duplicate_str" ]]; then
+            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1
         fi
 
@@ -83,6 +83,7 @@ runs:
         # which the Terraform project does not accept (possibly a typo). In some scenarios,
         # such as deprecations, it's nice to use environmental variables which when
         # undeclared in the project do not produce these errors.
+        # https://github.com/hashicorp/terraform/issues/22004#issuecomment-783757089
         #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -15,12 +15,16 @@ inputs:
     description: Boolean which specifies if a state lock is to be held during the operation.
     default: "true"
   variables:
-    description: YAML or JSON object containing key/value pairs specifying input values.
-    required: false
-  allow-undeclared:
     description: >-
-      YAML or JSON list containing the names of variable keys which may safely be ignored
-      when they are specified as input but are undeclared within the called Terraform project.
+      YAML or JSON object containing key/value pairs specifying input values. Any variables
+      specified here must be declared by the Terraform project or otherwise an error will
+      be thrown.
+    required: false
+  optional-variables:
+    description: >-
+      YAML or JSON object containing key/value pairs of input values which may can be
+      ignored if the Terraform project doesn't declare them. Typically, users should prefer
+      using `variables` instead.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
@@ -41,23 +45,30 @@ runs:
       run: |
         # Terraform variables
         set -eo pipefail
-        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
-        allow_undeclared_json="$(yq '. // []' -o json <<<"${allow_undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
+        required_vars_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
+        optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
+
+        # Keys may only be defined once in either of the input lists
+        duplicate_vars_str="$(jq -n --argjson req "$required_json" --argjson opt "$optional_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        if [[ -n "$duplicate_vars_str" ]]; then
+            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_vars_str" >&2
+            exit 1
+        fi
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
-            echo "variables-json<<EOF"
-            jq <<<"${variables_json}"
+            echo "required-json<<EOF"
+            jq <<<"${required_vars_json}"
             echo "EOF"
 
-            echo "allow-undeclared-json<<EOF"
-            jq <<<"${allow_undeclared_json}"
+            echo "optional-json<<EOF"
+            jq <<<"${optional_vars_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:
         variables: ${{ inputs.variables }}
-        allow_undeclared: ${{ inputs.allow-undeclared }}
+        optional_variables: ${{ inputs.optional-variables }}
     - name: Terraform apply
       shell: bash
       run: |
@@ -68,24 +79,22 @@ runs:
         # entries with `null` values as we cannot pass those into Terraform:
         # https://github.com/hashicorp/terraform/issues/29078
         #
+        # Prefer using flags where possible as these will error when they define a variable
+        # which the Terraform project does not accept (possibly a typo). In some scenarios,
+        # such as deprecations, it's nice to use environmental variables which when
+        # undeclared in the project do not produce these errors.
+        #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
         tf_var_flags=()
-        tf_var_envs=()
-        while read -r json; do
-            key="$(jq -re '.key' <<<"${json}")"
-            value="$(jq -re '.value | tostring' <<<"${json}")"
+        while read -r var; do
+            tf_var_flags+=(-var "${var:?}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${required_vars_json}")
 
-            # Prefer using flags where possible as these will error when they define a variable
-            # which the Terraform project does not accept (possibly a typo). In some scenarios,
-            # such as deprecations, it's nice to use environmental variables which when unused
-            # do not produce these errors.
-            if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
-                tf_var_envs+=(TF_VAR_${key}="${value}")
-            else
-                tf_var_flags+=(-var "${key}=${value}")
-            fi
-        done < <(jq -cr 'to_entries[] | select(.value != null)' <<<"${variables_json}")
+        tf_var_envs=()
+        while read -r env; do
+            tf_var_envs+=("${env:?}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "TF_VAR_\(.key)=\(.value | tostring)"' <<<"${optional_vars_json}")
 
         echo "::group::terraform init"
         terraform init
@@ -109,8 +118,8 @@ runs:
 
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
-        variables_json: ${{ steps.variables.outputs.variables-json }}
-        allow_undeclared_json: ${{ steps.variables.outputs.allow-undeclared-json }}
+        required_vars_json: ${{ steps.variables.outputs.required-json }}
+        optional_vars_json: ${{ steps.variables.outputs.optional-json }}
       working-directory: ${{ inputs.dir }}
     - name: Terraform outputs
       id: outputs

--- a/destroy/README.md
+++ b/destroy/README.md
@@ -6,13 +6,14 @@ Perform a Terraform [destroy](https://developer.hashicorp.com/terraform/cli/comm
 
 The `terraform-action/destroy` action supports the following inputs:
 
-| Name             | Description | Required | Example |
-|:-----------------|:------------|:---------|:--------|
-| `dir`            | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
-| `workspace`      | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
-| `lock`           | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
-| `variables`      | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `token`          | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
+| Name               | Description | Required | Example |
+|:-------------------|:------------|:---------|:--------|
+| `dir`              | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
+| `workspace`        | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
+| `lock`             | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
+| `variables`        | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `allow-undeclared` | YAML or JSON list containing the names of variable keys which may safely be ignored when they are specified as input but are undeclared within the called Terraform project. | No |<pre><code class="language-yaml">- availability_zone_names</code></pre> |
+| `token`            | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs
 

--- a/destroy/README.md
+++ b/destroy/README.md
@@ -12,7 +12,7 @@ The `terraform-action/destroy` action supports the following inputs:
 | `workspace`          | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
 | `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
 | `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). Any variables specified here must be declared by the Terraform project or otherwise an error will be thrown. | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `optional-variables` | YAML or JSON object containing key/value pairs of input values which may can be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `optional-variables` | YAML or JSON object containing key/value pairs of input values which will be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
 | `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs

--- a/destroy/README.md
+++ b/destroy/README.md
@@ -6,14 +6,14 @@ Perform a Terraform [destroy](https://developer.hashicorp.com/terraform/cli/comm
 
 The `terraform-action/destroy` action supports the following inputs:
 
-| Name               | Description | Required | Example |
-|:-------------------|:------------|:---------|:--------|
-| `dir`              | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
-| `workspace`        | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
-| `lock`             | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
-| `variables`        | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
-| `allow-undeclared` | YAML or JSON list containing the names of variable keys which may safely be ignored when they are specified as input but are undeclared within the called Terraform project. | No |<pre><code class="language-yaml">- availability_zone_names</code></pre> |
-| `token`            | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
+| Name                 | Description | Required | Example |
+|:---------------------|:------------|:---------|:--------|
+| `dir`                | The working directory containing the Terraform project. Defaults to `"."` | No | `".terraform"` |
+| `workspace`          | Name of the Terraform workspace to use during the operation. | No | `${{ github.event.number }}` |
+| `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
+| `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). Any variables specified here must be declared by the Terraform project or otherwise an error will be thrown. | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `optional-variables` | YAML or JSON object containing key/value pairs of input values which may can be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs
 

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -82,11 +82,16 @@ runs:
         terraform init
         echo "::endgroup::"
 
-        if terraform workspace select "${workspace:?}"; then
-            echo "::group::terraform destroy"
-            (set -x; env "${tf_var_envs[@]}" terraform destroy -auto-approve -lock="$lock" -input=false "${tf_var_flags[@]}")
-            echo "::endgroup::"
+        if [[ -n "$workspace" ]]; then
+            # When the workspace doesn't exist then there are no resources to delete
+            terraform workspace select "${workspace}" || exit 0
+        fi
 
+        echo "::group::terraform destroy"
+        (set -x; env "${tf_var_envs[@]}" terraform destroy -auto-approve -lock="$lock" -input=false "${tf_var_flags[@]}")
+        echo "::endgroup::"
+
+        if [[ -n "$workspace" ]]; then
             # The "default" workspace always exists:
             # https://developer.hashicorp.com/terraform/language/state/workspaces#using-workspaces
             terraform workspace select default

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -17,12 +17,16 @@ inputs:
     description: Boolean which specifies if a state lock is to be held during the operation.
     default: "true"
   variables:
-    description: YAML or JSON object containing key/value pairs specifying input values.
-    required: false
-  allow-undeclared:
     description: >-
-      YAML or JSON list containing the names of variable keys which may safely be ignored
-      when they are specified as input but are undeclared within the called Terraform project.
+      YAML or JSON object containing key/value pairs specifying input values. Any variables
+      specified here must be declared by the Terraform project or otherwise an error will
+      be thrown.
+    required: false
+  optional-variables:
+    description: >-
+      YAML or JSON object containing key/value pairs of input values which may can be
+      ignored if the Terraform project doesn't declare them. Typically, users should prefer
+      using `variables` instead.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
@@ -36,23 +40,30 @@ runs:
       run: |
         # Terraform variables
         set -eo pipefail
-        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
-        allow_undeclared_json="$(yq '. // []' -o json <<<"${allow_undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
+        required_vars_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
+        optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
+
+        # Keys may only be defined once in either of the input lists
+        duplicate_vars_str="$(jq -n --argjson req "$required_json" --argjson opt "$optional_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        if [[ -n "$duplicate_vars_str" ]]; then
+            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_vars_str" >&2
+            exit 1
+        fi
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
-            echo "variables-json<<EOF"
-            jq <<<"${variables_json}"
+            echo "required-json<<EOF"
+            jq <<<"${required_vars_json}"
             echo "EOF"
 
-            echo "allow-undeclared-json<<EOF"
-            jq <<<"${allow_undeclared_json}"
+            echo "optional-json<<EOF"
+            jq <<<"${optional_vars_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:
         variables: ${{ inputs.variables }}
-        allow_undeclared: ${{ inputs.allow-undeclared }}
+        optional_variables: ${{ inputs.optional-variables }}
     - name: Terraform destroy
       shell: bash
       run: |
@@ -63,24 +74,22 @@ runs:
         # entries with `null` values as we cannot pass those into Terraform:
         # https://github.com/hashicorp/terraform/issues/29078
         #
+        # Prefer using flags where possible as these will error when they define a variable
+        # which the Terraform project does not accept (possibly a typo). In some scenarios,
+        # such as deprecations, it's nice to use environmental variables which when
+        # undeclared in the project do not produce these errors.
+        #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
         tf_var_flags=()
-        tf_var_envs=()
-        while read -r json; do
-            key="$(jq -re '.key' <<<"${json}")"
-            value="$(jq -re '.value | tostring' <<<"${json}")"
+        while read -r var; do
+            tf_var_flags+=(-var "${var:?}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${required_vars_json}")
 
-            # Prefer using flags where possible as these will error when they define a variable
-            # which the Terraform project does not accept (possibly a typo). In some scenarios,
-            # such as deprecations, it's nice to use environmental variables which when unused
-            # do not produce these errors.
-            if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
-                tf_var_envs+=(TF_VAR_${key}="${value}")
-            else
-                tf_var_flags+=(-var "${key}=${value}")
-            fi
-        done < <(jq -cr 'to_entries[] | select(.value != null)' <<<"${variables_json}")
+        tf_var_envs=()
+        while read -r env; do
+            tf_var_envs+=("${env:?}")
+        done < <(jq -r 'to_entries[] | select(.value != null) | "TF_VAR_\(.key)=\(.value | tostring)"' <<<"${optional_vars_json}")
 
         echo "::group::terraform init"
         terraform init
@@ -113,6 +122,6 @@ runs:
 
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
-        variables_json: ${{ steps.variables.outputs.variables-json }}
-        allow_undeclared_json: ${{ steps.variables.outputs.allow-undeclared-json }}
+        required_vars_json: ${{ steps.variables.outputs.required-json }}
+        optional_vars_json: ${{ steps.variables.outputs.optional-json }}
       working-directory: ${{ inputs.dir }}

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -46,7 +46,7 @@ runs:
         # Variables may only be defined once in either of the input variable maps
         duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
         if [[ -n "$duplicate_str" ]]; then
-            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_str" >&2
+            echo "Input variables must not be defined in both \`variables\` and \`optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1
         fi
 

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -44,7 +44,7 @@ runs:
         optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
 
         # Variables may only be defined once in either of the input variable maps
-        duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        duplicate_str="$(jq -nr --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
         if [[ -n "$duplicate_str" ]]; then
             echo "Input variables must not be defined in both \`variables\` and \`optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -19,6 +19,11 @@ inputs:
   variables:
     description: YAML or JSON object containing key/value pairs specifying input values.
     required: false
+  allow-undeclared:
+    description: >-
+      YAML or JSON list containing the names of variable keys which may safely be ignored
+      when the are specified as input but are undeclared by the called Terrafrom project.
+    required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
     default: ${{ github.token }}
@@ -31,33 +36,47 @@ runs:
       run: |
         # Terraform variables
         set -eo pipefail
-        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("root element must be an object") end')"
+        variables_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
+        allow_undeclared_json="$(yq '. // []' -o json <<<"${allow_undeclared}" | jq -r 'if type == "array" then . else error("\"undeclared\" root element must be a list") end')"
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
-            echo "json<<EOF"
+            echo "variables-json<<EOF"
             jq <<<"${variables_json}"
+            echo "EOF"
+
+            echo "allow-undeclared-json<<EOF"
+            jq <<<"${allow_undeclared_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:
         variables: ${{ inputs.variables }}
+        allow_undeclared: ${{ inputs.allow-undeclared }}
     - name: Terraform destroy
       shell: bash
       run: |
         # Destroy
         set -eo pipefail
 
-        # Convert JSON variables into CLI flags. We'll remove entries with `null` values as we cannot
-        # pass those into Terraform:
+        # Convert JSON variables into CLI flags or environmental variables. We'll remove
+        # entries with `null` values as we cannot pass those into Terraform:
         # https://github.com/hashicorp/terraform/issues/29078
         #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.
-        var_flags=()
-        while read -r var; do
-            var_flags+=(-var "${var:?}")
-        done < <(jq -r 'to_entries[] | select(.value != null) | "\(.key)=\(.value | tostring)"' <<<"${variables_json}")
+        tf_var_flags=()
+        tf_var_envs=()
+        while read -r json; do
+            key="$(jq -re '.key' <<<"${json}")"
+            value="$(jq -re '.value | tostring' <<<"${json}")"
+
+            if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
+                tf_var_envs+=(TF_VAR_${key}="${value}")
+            else
+                tf_var_flags+=(-var "${key}=${value}")
+            fi
+        done < <(jq -cr 'to_entries[] | select(.value != null)' <<<"${variables_json}")
 
         echo "::group::terraform init"
         terraform init
@@ -65,7 +84,7 @@ runs:
 
         if terraform workspace select "${workspace:?}"; then
             echo "::group::terraform destroy"
-            (set -x; terraform destroy -auto-approve -lock="$lock" -input=false "${var_flags[@]}")
+            (set -x; env "${tf_var_envs[@]}" terraform destroy -auto-approve -lock="$lock" -input=false "${tf_var_flags[@]}")
             echo "::endgroup::"
 
             # The "default" workspace always exists:
@@ -85,5 +104,6 @@ runs:
 
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
-        variables_json: ${{ steps.variables.outputs.json }}
+        variables_json: ${{ steps.variables.outputs.variables-json }}
+        allow_undeclared_json: ${{ steps.variables.outputs.allow-undeclared-json }}
       working-directory: ${{ inputs.dir }}

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -24,9 +24,9 @@ inputs:
     required: false
   optional-variables:
     description: >-
-      YAML or JSON object containing key/value pairs of input values which may can be
-      ignored if the Terraform project doesn't declare them. Typically, users should prefer
-      using `variables` instead.
+      YAML or JSON object containing key/value pairs of input values which will be ignored
+      if the Terraform project doesn't declare them. Typically, users should prefer using
+      `variables` instead.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -71,6 +71,10 @@ runs:
             key="$(jq -re '.key' <<<"${json}")"
             value="$(jq -re '.value | tostring' <<<"${json}")"
 
+            # Prefer using flags where possible as these will error when they define a variable
+            # which the Terraform project does not accept (possibly a typo). In some scenarios,
+            # such as deprecations, it's nice to use environmental variables which when unused
+            # do not produce these errors.
             if jq -e --arg key "$key" 'any(index($key))' <<<"${allow_undeclared_json}"; then
                 tf_var_envs+=(TF_VAR_${key}="${value}")
             else

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -43,10 +43,10 @@ runs:
         required_vars_json="$(yq '. // {}' -o json <<<"${variables}" | jq -r 'if type == "object" then . else error("\"variables\" root element must be an object") end')"
         optional_vars_json="$(yq '. // {}' -o json <<<"${optional_variables}" | jq -r 'if type == "object" then . else error("\"optional-variables\" root element must be an object") end')"
 
-        # Keys may only be defined once in either of the input lists
-        duplicate_vars_str="$(jq -n --argjson req "$required_json" --argjson opt "$optional_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
-        if [[ -n "$duplicate_vars_str" ]]; then
-            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_vars_str" >&2
+        # Variables may only be defined once in either of the input variable maps
+        duplicate_str="$(jq -n --argjson req "$required_vars_json" --argjson opt "$optional_vars_json" '($req | keys) - (($req | keys) - ($opt | keys)) | join(", ")')"
+        if [[ -n "$duplicate_str" ]]; then
+            echo "Input variables must not be defined in both \`variables\` and `optional-variables\`. Duplicates found: $duplicate_str" >&2
             exit 1
         fi
 
@@ -78,6 +78,7 @@ runs:
         # which the Terraform project does not accept (possibly a typo). In some scenarios,
         # such as deprecations, it's nice to use environmental variables which when
         # undeclared in the project do not produce these errors.
+        # https://github.com/hashicorp/terraform/issues/22004#issuecomment-783757089
         #
         # TODO: Add tests for JSON lists and values with spaces. If you aren't very careful can end up
         # with `'-var=foo="a b"'` which looks like a positional argument to terraform.

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -22,7 +22,7 @@ inputs:
   allow-undeclared:
     description: >-
       YAML or JSON list containing the names of variable keys which may safely be ignored
-      when the are specified as input but are undeclared by the called Terrafrom project.
+      when they are specified as input but are undeclared within the called Terraform project.
     required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.


### PR DESCRIPTION
I ran into a scenario where I wanted to update a CI workflow to start passing in a Terraform variable in preparation for a future update to the Terraform project. Terraform typically errors when input variables are set but unused by the Terraform project although there are [workarounds to this](https://github.com/hashicorp/terraform/issues/22004#issuecomment-783757089). This update allows some inputs variables to be allowed to be undeclared without erroring.

A couple of notes:
- We should utilize a common script or GHA for variable processing to avoid having to copy the logic between the two actions. I'll open an issue for that: https://github.com/beacon-biosignals/terraform-action/issues/11
- To test this the integration tests have been refactored to test the Terraform behavior on inputs/outputs.
- A bug was discovered where a workspace was not optional for destroy.