### PR TITLE
Allow specifying the log-level

### DIFF
--- a/apply/README.md
+++ b/apply/README.md
@@ -13,6 +13,7 @@ The `terraform-action/apply` action supports the following inputs:
 | `lock`               | Boolean which specifies if a state lock is to be held during the operation. May be set to `false` if utilizing GitHub action concurrency groups to restrict access. Defaults to `"true"` | No | `"true"` |
 | `variables`          | YAML or JSON object containing key/value pairs specifying [input values](https://developer.hashicorp.com/terraform/language/values/variables). Any variables specified here must be declared by the Terraform project or otherwise an error will be thrown. | No | <pre><code class="language-yaml">image_id: ...&#10;availability_zone_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
 | `optional-variables` | YAML or JSON object containing key/value pairs of input values which will be ignored if the Terraform project doesn't declare them. Typically, users should prefer using `variables` instead. | No |<pre><code class="language-yaml">az_names:&#10;  - us-east-1a&#10;  - us-east-1b</code></pre> |
+| `log-level` | Set the verbosity of the Terraform logs: TRACE, DEBUG, INFO, WARN, or ERROR. | No | `"DEBUG"` |
 | `token`              | The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub. Defaults to `${{ github.token }}` | No | |
 
 ## Outputs

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -26,6 +26,11 @@ inputs:
       if the Terraform project doesn't declare them. Typically, users should prefer using
       `variables` instead.
     required: false
+  log-level:
+    description: >-
+      Set the verbosity of the Terraform logs: TRACE, DEBUG, INFO, WARN, or ERROR.
+    default: "INFO"
+    required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
     default: ${{ github.token }}
@@ -55,6 +60,11 @@ runs:
             exit 1
         fi
 
+        if [[ ! "$log_level" =~ ^(TRACE|DEBUG|INFO|WARN|ERROR)$ ]]; then
+            echo "Input variable \`log-level\` must be one of: TRACE, DEBUG, INFO, WARN, or ERROR." >&2
+            exit 1
+        fi
+
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
@@ -69,6 +79,7 @@ runs:
       env:
         variables: ${{ inputs.variables }}
         optional_variables: ${{ inputs.optional-variables }}
+        log_level: ${{ inputs.log-level }}
     - name: Terraform apply
       shell: bash
       run: |
@@ -117,6 +128,7 @@ runs:
         GIT_CONFIG_KEY_0: url.https://git:${{ inputs.token }}@github.com.insteadOf
         GIT_CONFIG_VALUE_0: https://github.com
 
+        TF_LOG: ${{ inputs.log-level }}
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
         required_vars_json: ${{ steps.variables.outputs.required-json }}

--- a/destroy/action.yaml
+++ b/destroy/action.yaml
@@ -28,6 +28,11 @@ inputs:
       if the Terraform project doesn't declare them. Typically, users should prefer using
       `variables` instead.
     required: false
+  log-level:
+    description: >-
+      Set the verbosity of the Terraform logs: TRACE, DEBUG, INFO, WARN, or ERROR.
+    default: "INFO"
+    required: false
   token:
     description: The GitHub PAT token to use for accessing remote Terraform modules stored on GitHub.
     default: ${{ github.token }}
@@ -50,6 +55,11 @@ runs:
             exit 1
         fi
 
+        if [[ ! "$log_level" =~ ^(TRACE|DEBUG|INFO|WARN|ERROR)$ ]]; then
+            echo "Input variable \`log-level\` must be one of: TRACE, DEBUG, INFO, WARN, or ERROR." >&2
+            exit 1
+        fi
+
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
@@ -64,6 +74,7 @@ runs:
       env:
         variables: ${{ inputs.variables }}
         optional_variables: ${{ inputs.optional-variables }}
+        log_level: ${{ inputs.log-level }}
     - name: Terraform destroy
       shell: bash
       run: |
@@ -121,6 +132,7 @@ runs:
         GIT_CONFIG_KEY_0: url.https://git:${{ inputs.token }}@github.com.insteadOf
         GIT_CONFIG_VALUE_0: https://github.com
 
+        TF_LOG: ${{ inputs.log-level }}
         workspace: ${{ inputs.workspace }}
         lock: ${{ inputs.lock }}
         required_vars_json: ${{ steps.variables.outputs.required-json }}


### PR DESCRIPTION
Being able to set the `TF_LOG` value seems useful in debugging issue: https://developer.hashicorp.com/terraform/internals/debugging#enable-terraform-logs